### PR TITLE
Fix ETag template in advanced cache middleware

### DIFF
--- a/middleware/optimized/advancedCache.js
+++ b/middleware/optimized/advancedCache.js
@@ -91,9 +91,12 @@ function cacheMiddleware(options = {}) {
     // Override send function
     res.json = function(body) {
       // Generate ETag if enabled
-      const etag = useEtag ? 
-        `"${require('crypto').createHash('md5').update(JSON.stringify(body)).digest('hex')}"` : 
-        null;
+      const etag = useEtag
+        ? `"${require('crypto')
+            .createHash('md5')
+            .update(JSON.stringify(body))
+            .digest('hex')}"`
+        : null;
       
       // Store the response in cache
       cache.set(cacheKey, { 


### PR DESCRIPTION
## Summary
- fix template literal formatting for ETag generation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844159d3e4c8326aee9a47434110e51